### PR TITLE
Deprecate unversioned API helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ See the full changelog at https://github.com/iamkaf/amber
 ### Deprecated
 
 - AmberMod is now deprecated in favor of AmberInitializer.
+- All unversioned API helper classes have been deprecated in preparation for versioned packages.
 
 ### Removed
 

--- a/common/src/main/java/com/iamkaf/amber/api/aabb/BoundingBoxMerger.java
+++ b/common/src/main/java/com/iamkaf/amber/api/aabb/BoundingBoxMerger.java
@@ -12,6 +12,10 @@ import net.minecraft.world.phys.Vec3;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public final class BoundingBoxMerger {
     private static final Long2ObjectMap<Direction> DIRECTION_LOOKUP = Arrays.stream(Direction.values())
             .collect(Collectors.toMap(dir -> new BlockPos(dir.getUnitVec3i()).asLong(),

--- a/common/src/main/java/com/iamkaf/amber/api/component/SimpleIntegerDataComponent.java
+++ b/common/src/main/java/com/iamkaf/amber/api/component/SimpleIntegerDataComponent.java
@@ -2,10 +2,12 @@ package com.iamkaf.amber.api.component;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-
 /**
  * A simple record class that represents an integer-based data component.
+ *
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
  */
+@Deprecated
 public record SimpleIntegerDataComponent(int value) {
 
     /**

--- a/common/src/main/java/com/iamkaf/amber/api/core/AmberMod.java
+++ b/common/src/main/java/com/iamkaf/amber/api/core/AmberMod.java
@@ -5,6 +5,7 @@ import net.minecraft.resources.ResourceLocation;
 /**
  * @deprecated Use {@link com.iamkaf.amber.api.core.v2.AmberInitializer} instead.
  */
+@Deprecated
 public class AmberMod {
     private final String ID;
 

--- a/common/src/main/java/com/iamkaf/amber/api/enchantment/EnchantmentUtils.java
+++ b/common/src/main/java/com/iamkaf/amber/api/enchantment/EnchantmentUtils.java
@@ -3,6 +3,10 @@ package com.iamkaf.amber.api.enchantment;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class EnchantmentUtils {
     public static boolean containsEnchantment(ItemStack stack, ResourceLocation enchantment) {
         if (!stack.isEnchanted() || stack.getEnchantments().isEmpty()) {

--- a/common/src/main/java/com/iamkaf/amber/api/inventory/InventoryHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/inventory/InventoryHelper.java
@@ -9,6 +9,10 @@ import net.minecraft.world.level.ItemLike;
 
 import java.util.function.Consumer;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class InventoryHelper {
     /**
      * Checks if the inventory contains the item and shrinks the stack by one.

--- a/common/src/main/java/com/iamkaf/amber/api/inventory/ItemHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/inventory/ItemHelper.java
@@ -17,6 +17,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class ItemHelper {
     /**
      * Repairs the item by the given percentage of its maximum durability.

--- a/common/src/main/java/com/iamkaf/amber/api/item/ArmorTierHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/item/ArmorTierHelper.java
@@ -5,6 +5,10 @@ import net.minecraft.world.item.crafting.Ingredient;
 
 import java.util.function.Supplier;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class ArmorTierHelper {
     public static Supplier<Ingredient> repair(Supplier<Item> item) {
         return () -> Ingredient.of(item.get());

--- a/common/src/main/java/com/iamkaf/amber/api/item/BrewingHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/item/BrewingHelper.java
@@ -7,6 +7,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class BrewingHelper {
     private static List<Consumer<PotionBrewing.Builder>> listeners = new ArrayList<>();
 

--- a/common/src/main/java/com/iamkaf/amber/api/item/SmartTooltip.java
+++ b/common/src/main/java/com/iamkaf/amber/api/item/SmartTooltip.java
@@ -17,6 +17,10 @@ import java.util.function.Consumer;
  * This class allows adding tooltip components conditionally based on player
  * key presses or modifier keys.
  */
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class SmartTooltip {
     // List of tooltip components to display.
     private final List<Component> tooltipComponents = new ArrayList<>();

--- a/common/src/main/java/com/iamkaf/amber/api/level/LevelHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/level/LevelHelper.java
@@ -8,6 +8,10 @@ import net.minecraft.world.phys.Vec3;
 
 import java.util.function.Consumer;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class LevelHelper {
 
     /**

--- a/common/src/main/java/com/iamkaf/amber/api/math/Chance.java
+++ b/common/src/main/java/com/iamkaf/amber/api/math/Chance.java
@@ -2,6 +2,10 @@ package com.iamkaf.amber.api.math;
 
 import java.util.Random;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class Chance {
     /**
      * Simulates a random event occurring with a specified probability.

--- a/common/src/main/java/com/iamkaf/amber/api/player/FeedbackHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/player/FeedbackHelper.java
@@ -3,6 +3,10 @@ package com.iamkaf.amber.api.player;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class FeedbackHelper {
     public static void message(Player player, Component component) {
         player.displayClientMessage(component, false);

--- a/common/src/main/java/com/iamkaf/amber/api/sound/SoundHelper.java
+++ b/common/src/main/java/com/iamkaf/amber/api/sound/SoundHelper.java
@@ -7,6 +7,10 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class SoundHelper {
     public static void sendClientSound(Player player, SoundEvent sound) {
         sendClientSound(player, sound, SoundSource.PLAYERS, 1f, 1f);

--- a/common/src/main/java/com/iamkaf/amber/api/util/LiteralSetHolder.java
+++ b/common/src/main/java/com/iamkaf/amber/api/util/LiteralSetHolder.java
@@ -2,6 +2,10 @@ package com.iamkaf.amber.api.util;
 
 import java.util.HashSet;
 
+/**
+ * @deprecated This helper will be replaced by a versioned alternative in a future release.
+ */
+@Deprecated
 public class LiteralSetHolder<T> {
     private final HashSet<T> set = new HashSet<>();
 


### PR DESCRIPTION
## Summary
- deprecate every helper in the API that isn't under a versioned package
- document the mass deprecations in the changelog

## Testing
- `./gradlew test --no-daemon` *(fails: Compiling many source files)*

------
https://chatgpt.com/codex/tasks/task_e_6861c3ec84e48331809e53a7c42bfaa0