### PR TITLE
Release Amber 11.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,11 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: |
+            16
+            17
+            25
+            21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -111,7 +115,11 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: |
+            16
+            17
+            25
+            21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,27 +74,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect Java version
-        id: java
-        shell: bash
-        run: |
-          set -euo pipefail
-          props="versions/${{ matrix.version }}/gradle.properties"
-          v=$(sed -nE 's/^project\.build-java=([0-9]+).*/\1/p' "$props" | head -n1)
-          if [ -z "$v" ]; then
-            v=$(sed -nE 's/^project\.java=([0-9]+).*/\1/p' "$props" | head -n1)
-          fi
-          if [ -z "$v" ]; then
-            echo "project.build-java/project.java not found in $props" >&2
-            exit 1
-          fi
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ steps.java.outputs.version }}
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -123,24 +107,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect Java version
-        id: java
-        shell: bash
-        run: |
-          set -euo pipefail
-          first_version=$(printf '%s\n' '${{ needs.detect-changes.outputs.versions }}' | jq -r '.[0]')
-          props="versions/$first_version/gradle.properties"
-          v=$(sed -nE 's/^project\.build-java=([0-9]+).*/\1/p' "$props" | head -n1)
-          if [ -z "$v" ]; then
-            v=$(sed -nE 's/^project\.java=([0-9]+).*/\1/p' "$props" | head -n1)
-          fi
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ steps.java.outputs.version }}
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             versions="$all_versions"
           else
             changed_versions=$(printf '%s\n' "$changed_files" | sed -nE 's|^versions/([^/]+)/.*|\1|p' | sort -u)
-            versions=$(comm -12 <(printf '%s\n' "$all_versions") <(printf '%s\n' "$changed_versions"))
+            versions=$(grep -Fxf <(printf '%s\n' "$changed_versions") <(printf '%s\n' "$all_versions") || true)
           fi
 
           versions_json=$(printf '%s\n' "$versions" | jq -R -s -c 'split("\n") | map(select(length > 0))')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,16 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build ${{ matrix.node }}
-        run: just build ${{ matrix.node }}
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            just build "${{ matrix.node }}" && exit 0
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 20))
+          done
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -131,7 +140,16 @@ jobs:
         run: chmod +x gradlew
 
       - name: Compile all changed nodes
-        run: just compile-all
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            just compile-all && exit 0
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 20))
+          done
 
   summary:
     needs: [build, test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,11 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: |
+            16
+            17
+            25
+            21
           cache: gradle
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,27 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect Java version
-        id: java
-        shell: bash
-        run: |
-          set -euo pipefail
-          props="versions/${{ matrix.version }}/gradle.properties"
-          v=$(sed -nE 's/^project\.build-java=([0-9]+).*/\1/p' "$props" | head -n1)
-          if [ -z "$v" ]; then
-            v=$(sed -nE 's/^project\.java=([0-9]+).*/\1/p' "$props" | head -n1)
-          fi
-          if [ -z "$v" ]; then
-            echo "project.build-java/project.java not found in $props" >&2
-            exit 1
-          fi
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ steps.java.outputs.version }}
+          java-version: 21
           cache: gradle
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,4 +82,13 @@ jobs:
         env:
           MAVEN_PUBLISH_USERNAME: ${{ secrets.MAVEN_PUBLISH_USERNAME }}
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.MAVEN_PUBLISH_PASSWORD }}
-        run: just publish-version "${{ matrix.version }}"
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            just publish-version "${{ matrix.version }}" && exit 0
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 20))
+          done

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'com.iamkaf.multiloader.root' apply false
+}
+
+if (project == rootProject) {
+    apply plugin: 'com.iamkaf.multiloader.root'
+}

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See the full changelog at https://github.com/iamkaf/amber
 
+## 11.0.1
+
+### Fixed
+
+- Fixed Forge world lifecycle callbacks forwarding client-only level load events without a server.
+
 ## 11.0.0
 
 ### Added

--- a/common/src/main/java/com/iamkaf/amber/api/registry/v1/creativetabs/TabBuilder.java
+++ b/common/src/main/java/com/iamkaf/amber/api/registry/v1/creativetabs/TabBuilder.java
@@ -275,20 +275,31 @@ public class TabBuilder {
         }
         return builder.build();
         //?} else {
-        /*return new CreativeModeTab(nextLegacyTabIndex(), legacyTabName(id)) {
+        /*class LegacyCreativeModeTab extends CreativeModeTab {
+            private final Identifier tabId;
+            private final Supplier<ItemStack> tabIcon;
+            private final List<Supplier<ItemLike>> tabItems;
+
+            private LegacyCreativeModeTab(int index, String name, Identifier tabId, Supplier<ItemStack> tabIcon, List<Supplier<ItemLike>> tabItems) {
+                super(index, name);
+                this.tabId = tabId;
+                this.tabIcon = tabIcon;
+                this.tabItems = tabItems;
+            }
+
             @Override
             public ItemStack makeIcon() {
-                return icon.get();
+                return tabIcon.get();
             }
 
             @Override
             public void fillItemList(NonNullList<ItemStack> stacks) {
-                for (Supplier<ItemLike> item : items) {
+                for (Supplier<ItemLike> item : tabItems) {
                     stacks.add(new ItemStack(item.get()));
                 }
                 com.iamkaf.amber.api.event.v1.events.common.CreativeModeTabEvents.MODIFY_ENTRIES.invoker()
                         .modifyEntries(
-                                CreativeTabHelper.creativeModeTabKey(id),
+                                CreativeTabHelper.creativeModeTabKey(tabId),
                                 new com.iamkaf.amber.api.event.v1.events.common.CreativeModeTabOutput() {
                                     @Override
                                     public void accept(ItemStack stack, com.iamkaf.amber.api.event.v1.events.common.CreativeModeTabOutput.TabVisibility visibility) {
@@ -297,7 +308,8 @@ public class TabBuilder {
                                 }
                         );
             }
-        };*/
+        }
+        return new LegacyCreativeModeTab(nextLegacyTabIndex(), legacyTabName(id), id, icon, items);*/
         //?}
     }
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -22,12 +22,12 @@ def minecraftVersionAtLeast = { String targetVersion ->
 }
 
 configurations.configureEach {
-    resolutionStrategy.dependencySubstitution {
-        all { dependency ->
-            def requested = dependency.requested
-            if (requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector && requested.group == 'com.terraformersmc' && requested.module == 'modmenu') {
-                dependency.useTarget "maven.modrinth:mOgUt4GM:${requested.version}"
-            }
+    withDependencies { dependencies ->
+        dependencies.findAll { dependency ->
+            dependency.group == 'com.terraformersmc' && dependency.name == 'modmenu'
+        }.toList().each { dependency ->
+            dependencies.remove(dependency)
+            dependencies.add(project.dependencies.create("maven.modrinth:mOgUt4GM:${dependency.version}"))
         }
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -21,6 +21,15 @@ def minecraftVersionAtLeast = { String targetVersion ->
     return true
 }
 
+configurations.configureEach {
+    resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'com.terraformersmc' && details.requested.name == 'modmenu') {
+            details.useTarget "maven.modrinth:mOgUt4GM:${details.requested.version}"
+            details.because 'Modrinth Maven is more reliable from GitHub Actions for Mod Menu'
+        }
+    }
+}
+
 tasks.named('stageMergedJavaSources').configure {
     if (minecraftVersion == '1.14.4' || minecraftVersion == '1.15' || minecraftVersion.startsWith('1.15.')) {
         from rootProject.file('common/src/legacy-pre116/java')

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -22,10 +22,12 @@ def minecraftVersionAtLeast = { String targetVersion ->
 }
 
 configurations.configureEach {
-    resolutionStrategy.eachDependency { details ->
-        if (details.requested.group == 'com.terraformersmc' && details.requested.name == 'modmenu') {
-            details.useTarget "maven.modrinth:mOgUt4GM:${details.requested.version}"
-            details.because 'Modrinth Maven is more reliable from GitHub Actions for Mod Menu'
+    resolutionStrategy.dependencySubstitution {
+        all { dependency ->
+            def requested = dependency.requested
+            if (requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector && requested.group == 'com.terraformersmc' && requested.module == 'modmenu') {
+                dependency.useTarget "maven.modrinth:mOgUt4GM:${requested.version}"
+            }
         }
     }
 }

--- a/justfile
+++ b/justfile
@@ -32,9 +32,13 @@ build-all:
 publish-version version *args:
   @tasks=(":common:{{version}}:publishAllPublicationsToKafMavenRepository"); for loader in $(just list-loaders "{{version}}"); do tasks+=(":$loader:{{version}}:publishAllPublicationsToKafMavenRepository"); done; ./gradlew --configure-on-demand "${tasks[@]}" {{args}} --console=plain
 
+publish-mod-version version *args:
+  @if [ ! -f "versions/{{version}}/gradle.properties" ]; then echo "Unknown version: {{version}}"; exit 1; fi
+  @tasks=(); for loader in $(just list-loaders "{{version}}"); do suffix=$(printf '%s-%s\n' "{{version}}" "$loader" | sed -E 's/[^A-Za-z0-9]+/ /g' | awk '{ out=""; for (i=1; i<=NF; i++) out = out toupper(substr($i,1,1)) substr($i,2); print out }'); tasks+=("publishCurseforge$suffix" "publishModrinth$suffix"); done; ./gradlew "${tasks[@]}" {{args}} --console=plain
+
 publish-all *args:
-  @test -n "$MAVEN_PUBLISH_USERNAME" || (echo "MAVEN_PUBLISH_USERNAME is required" >&2; exit 1)
-  @test -n "$MAVEN_PUBLISH_PASSWORD" || (echo "MAVEN_PUBLISH_PASSWORD is required" >&2; exit 1)
+  @test -n "${MAVEN_PUBLISH_USERNAME:-}" || (echo "MAVEN_PUBLISH_USERNAME is required" >&2; exit 1)
+  @test -n "${MAVEN_PUBLISH_PASSWORD:-}" || (echo "MAVEN_PUBLISH_PASSWORD is required" >&2; exit 1)
   @for version in $(just list-versions); do echo "==> publish $version"; just publish-version "$version" {{args}}; done
 
 compile-all:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,12 @@ pluginManagement {
     repositories {
         mavenLocal()
         maven("https://maven.kaf.sh") { name = "Kaf Maven" }
-        maven("https://maven.kikugie.dev/snapshots") { name = "KikuGie Snapshots" }
+        maven("https://maven.kikugie.dev/snapshots") {
+            name = "KikuGie Snapshots"
+            content {
+                includeGroupByRegex("dev\\.kikugie(\\..*)?")
+            }
+        }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/versions/1.14.4/gradle.properties
+++ b/versions/1.14.4/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.14.4
+project.version=11.0.1+1.14.4
 project.java=16
 project.build-java=17
 project.minecraft=1.14.4

--- a/versions/1.15.1/gradle.properties
+++ b/versions/1.15.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.15.1
+project.version=11.0.1+1.15.1
 project.java=16
 project.build-java=17
 project.minecraft=1.15.1

--- a/versions/1.15.2/gradle.properties
+++ b/versions/1.15.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.15.2
+project.version=11.0.1+1.15.2
 project.java=16
 project.build-java=17
 project.minecraft=1.15.2

--- a/versions/1.15/gradle.properties
+++ b/versions/1.15/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.15
+project.version=11.0.1+1.15
 project.java=16
 project.build-java=17
 project.minecraft=1.15

--- a/versions/1.16.1/gradle.properties
+++ b/versions/1.16.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.16.1
+project.version=11.0.1+1.16.1
 project.java=16
 project.build-java=17
 project.minecraft=1.16.1

--- a/versions/1.16.2/gradle.properties
+++ b/versions/1.16.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.16.2
+project.version=11.0.1+1.16.2
 project.java=16
 project.build-java=17
 project.minecraft=1.16.2

--- a/versions/1.16.3/gradle.properties
+++ b/versions/1.16.3/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.16.3
+project.version=11.0.1+1.16.3
 project.java=16
 project.build-java=17
 project.minecraft=1.16.3

--- a/versions/1.16.4/gradle.properties
+++ b/versions/1.16.4/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.16.4
+project.version=11.0.1+1.16.4
 project.java=16
 project.build-java=17
 project.minecraft=1.16.4

--- a/versions/1.16.5/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.16.5/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -552,43 +552,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(WorldEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getWorld());
+        }
 
+        public static void onWorldUnload(WorldEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getWorld());
+        }
 
-                WorldEvent.Load event
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-
-                WorldEvent.Unload event
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldSave(
-
-
-                WorldEvent.Save event
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
+        public static void onWorldSave(WorldEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getWorld());
+        }
 
 
 	        private static net.minecraft.server.MinecraftServer legacyServer(Object level) {

--- a/versions/1.16.5/gradle.properties
+++ b/versions/1.16.5/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.16.5
+project.version=11.0.1+1.16.5
 project.java=16
 project.build-java=17
 project.minecraft=1.16.5

--- a/versions/1.16/gradle.properties
+++ b/versions/1.16/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.16
+project.version=11.0.1+1.16
 project.java=16
 project.build-java=17
 project.minecraft=1.16

--- a/versions/1.17.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.17.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -555,43 +555,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(WorldEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getWorld());
+        }
 
+        public static void onWorldUnload(WorldEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getWorld());
+        }
 
-                WorldEvent.Load event
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-
-                WorldEvent.Unload event
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldSave(
-
-
-                WorldEvent.Save event
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
+        public static void onWorldSave(WorldEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getWorld());
+        }
 
 
 	        private static net.minecraft.server.MinecraftServer legacyServer(Object level) {

--- a/versions/1.17.1/gradle.properties
+++ b/versions/1.17.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.17.1
+project.version=11.0.1+1.17.1
 project.java=16
 project.build-java=21
 project.minecraft=1.17.1

--- a/versions/1.17/gradle.properties
+++ b/versions/1.17/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.17
+project.version=11.0.1+1.17
 project.java=16
 project.build-java=21
 project.minecraft=1.17

--- a/versions/1.18.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.18.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -550,43 +550,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(WorldEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getWorld());
+        }
 
+        public static void onWorldUnload(WorldEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getWorld());
+        }
 
-                WorldEvent.Load event
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-
-                WorldEvent.Unload event
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldSave(
-
-
-                WorldEvent.Save event
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
+        public static void onWorldSave(WorldEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getWorld());
+        }
 
 
 	        private static net.minecraft.server.MinecraftServer legacyServer(Object level) {

--- a/versions/1.18.1/gradle.properties
+++ b/versions/1.18.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.18.1
+project.version=11.0.1+1.18.1
 project.java=17
 project.build-java=21
 project.minecraft=1.18.1

--- a/versions/1.18.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.18.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -553,43 +553,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(WorldEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getWorld());
+        }
 
+        public static void onWorldUnload(WorldEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getWorld());
+        }
 
-                WorldEvent.Load event
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-
-                WorldEvent.Unload event
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldSave(
-
-
-                WorldEvent.Save event
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
+        public static void onWorldSave(WorldEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getWorld());
+        }
 
 
 	        private static net.minecraft.server.MinecraftServer legacyServer(Object level) {

--- a/versions/1.18.2/gradle.properties
+++ b/versions/1.18.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.18.2
+project.version=11.0.1+1.18.2
 project.java=17
 project.build-java=21
 project.minecraft=1.18.2

--- a/versions/1.18/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.18/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -557,43 +557,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(WorldEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getWorld());
+        }
 
+        public static void onWorldUnload(WorldEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getWorld());
+        }
 
-                WorldEvent.Load event
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-
-                WorldEvent.Unload event
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
-
-        public static void onWorldSave(
-
-
-                WorldEvent.Save event
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-
-	                    legacyServer(event.getWorld()), event.getWorld()
-	            );
-	        }
+        public static void onWorldSave(WorldEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = legacyServer(event.getWorld());
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getWorld());
+        }
 
 
 	        private static net.minecraft.server.MinecraftServer legacyServer(Object level) {

--- a/versions/1.18/gradle.properties
+++ b/versions/1.18/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.18
+project.version=11.0.1+1.18
 project.java=17
 project.build-java=21
 project.minecraft=1.18

--- a/versions/1.19.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.19.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -529,49 +529,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.19.1/gradle.properties
+++ b/versions/1.19.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.19.1
+project.version=11.0.1+1.19.1
 project.java=17
 project.build-java=21
 project.minecraft=1.19.1

--- a/versions/1.19.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.19.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -529,49 +529,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.19.2/gradle.properties
+++ b/versions/1.19.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.19.2
+project.version=11.0.1+1.19.2
 project.java=17
 project.build-java=21
 project.minecraft=1.19.2

--- a/versions/1.19.3/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.19.3/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -533,49 +533,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.19.3/gradle.properties
+++ b/versions/1.19.3/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.19.3
+project.version=11.0.1+1.19.3
 project.java=17
 project.build-java=21
 project.minecraft=1.19.3

--- a/versions/1.19.4/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.19.4/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -533,49 +533,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.19.4/gradle.properties
+++ b/versions/1.19.4/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.19.4
+project.version=11.0.1+1.19.4
 project.java=17
 project.build-java=21
 project.minecraft=1.19.4

--- a/versions/1.19/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.19/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -529,49 +529,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.19/gradle.properties
+++ b/versions/1.19/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.19
+project.version=11.0.1+1.19
 project.java=17
 project.build-java=21
 project.minecraft=1.19

--- a/versions/1.20.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.20.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -525,49 +525,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.20.1/gradle.properties
+++ b/versions/1.20.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20.1
+project.version=11.0.1+1.20.1
 project.java=17
 project.build-java=21
 project.minecraft=1.20.1

--- a/versions/1.20.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.20.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -525,49 +525,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.20.2/gradle.properties
+++ b/versions/1.20.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20.2
+project.version=11.0.1+1.20.2
 project.java=17
 project.build-java=21
 project.minecraft=1.20.2

--- a/versions/1.20.3/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.20.3/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -525,49 +525,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.20.3/gradle.properties
+++ b/versions/1.20.3/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20.3
+project.version=11.0.1+1.20.3
 project.java=17
 project.build-java=21
 project.minecraft=1.20.3

--- a/versions/1.20.4/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.20.4/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -525,49 +525,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20.4
+project.version=11.0.1+1.20.4
 project.java=17
 project.build-java=21
 project.minecraft=1.20.4

--- a/versions/1.20.5/gradle.properties
+++ b/versions/1.20.5/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20.5
+project.version=11.0.1+1.20.5
 project.java=21
 project.build-java=21
 project.minecraft=1.20.5

--- a/versions/1.20.6/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.20.6/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -556,49 +556,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20.6
+project.version=11.0.1+1.20.6
 project.java=21
 project.build-java=21
 project.minecraft=1.20.6

--- a/versions/1.20/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.20/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -535,49 +535,29 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
+        public static void onWorldLoad(LevelEvent.Load event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-                LevelEvent.Load event
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-        ) {
-
-
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.20/gradle.properties
+++ b/versions/1.20/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.20
+project.version=11.0.1+1.20
 project.java=17
 project.build-java=21
 project.minecraft=1.20

--- a/versions/1.21.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -556,49 +556,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.1
+project.version=11.0.1+1.21.1
 project.java=21
 project.build-java=21
 project.minecraft=1.21.1

--- a/versions/1.21.10/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.10/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -553,49 +553,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.10
+project.version=11.0.1+1.21.10
 project.java=21
 project.build-java=21
 project.minecraft=1.21.10

--- a/versions/1.21.11/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.11/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -553,49 +553,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.11
+project.version=11.0.1+1.21.11
 project.java=21
 project.build-java=21
 project.minecraft=1.21.11

--- a/versions/1.21.2/gradle.properties
+++ b/versions/1.21.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.2
+project.version=11.0.1+1.21.2
 project.java=21
 project.build-java=21
 project.minecraft=1.21.2

--- a/versions/1.21.3/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.3/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -556,49 +556,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.3/gradle.properties
+++ b/versions/1.21.3/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.3
+project.version=11.0.1+1.21.3
 project.java=21
 project.build-java=21
 project.minecraft=1.21.3

--- a/versions/1.21.4/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.4/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -556,49 +556,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.4
+project.version=11.0.1+1.21.4
 project.java=21
 project.build-java=21
 project.minecraft=1.21.4

--- a/versions/1.21.5/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.5/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -557,49 +557,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.5
+project.version=11.0.1+1.21.5
 project.java=21
 project.build-java=21
 project.minecraft=1.21.5

--- a/versions/1.21.6/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.6/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -555,49 +555,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.6
+project.version=11.0.1+1.21.6
 project.java=21
 project.build-java=21
 project.minecraft=1.21.6

--- a/versions/1.21.7/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.7/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -555,49 +555,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.7/gradle.properties
+++ b/versions/1.21.7/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.7
+project.version=11.0.1+1.21.7
 project.java=21
 project.build-java=21
 project.minecraft=1.21.7

--- a/versions/1.21.8/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.8/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -555,49 +555,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.8
+project.version=11.0.1+1.21.8
 project.java=21
 project.build-java=21
 project.minecraft=1.21.8

--- a/versions/1.21.9/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21.9/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -555,49 +555,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21.9/gradle.properties
+++ b/versions/1.21.9/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21.9
+project.version=11.0.1+1.21.9
 project.java=21
 project.build-java=21
 project.minecraft=1.21.9

--- a/versions/1.21/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/1.21/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -556,49 +556,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+1.21
+project.version=11.0.1+1.21
 project.java=21
 project.build-java=21
 project.minecraft=1.21

--- a/versions/26.1.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/26.1.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -553,49 +553,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/26.1.1/gradle.properties
+++ b/versions/26.1.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+26.1.1
+project.version=11.0.1+26.1.1
 project.java=25
 project.build-java=25
 project.minecraft=26.1.1

--- a/versions/26.1.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/26.1.2/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -553,49 +553,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/26.1.2/gradle.properties
+++ b/versions/26.1.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+26.1.2
+project.version=11.0.1+26.1.2
 project.java=25
 project.build-java=25
 project.minecraft=26.1.2

--- a/versions/26.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
+++ b/versions/26.1/forge/src/main/java/com/iamkaf/amber/platform/ForgeAmberEventHandlers.java
@@ -553,49 +553,30 @@ final class ForgeAmberEventHandlers {
         }
 
 
-        public static void onWorldLoad(
-
-                LevelEvent.Load event
-
-
-        ) {
-
+        public static void onWorldLoad(LevelEvent.Load event) {
             rebuildItemComponentCacheIfReady();
-	            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_LOAD.invoker().onWorldLoad(server, event.getLevel());
+        }
 
-	                    event.getLevel().getServer(), event.getLevel()
+        public static void onWorldUnload(LevelEvent.Unload event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(server, event.getLevel());
+        }
 
-
-	            );
-	        }
-
-        public static void onWorldUnload(
-
-                LevelEvent.Unload event
-
-
-        ) {
-	            WorldEvents.WORLD_UNLOAD.invoker().onWorldUnload(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
-
-        public static void onWorldSave(
-
-                LevelEvent.Save event
-
-
-        ) {
-	            WorldEvents.WORLD_SAVE.invoker().onWorldSave(
-
-	                    event.getLevel().getServer(), event.getLevel()
-
-
-	            );
-	        }
+        public static void onWorldSave(LevelEvent.Save event) {
+            net.minecraft.server.MinecraftServer server = event.getLevel().getServer();
+            if (server == null) {
+                return;
+            }
+            WorldEvents.WORLD_SAVE.invoker().onWorldSave(server, event.getLevel());
+        }
 
 
         public static boolean onLightningStrike(EntityStruckByLightningEvent event) {

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -1,4 +1,4 @@
-project.version=11.0.0+26.1
+project.version=11.0.1+26.1
 project.java=25
 project.build-java=25
 project.minecraft=26.1


### PR DESCRIPTION
Amber 11.0.1 fixes the Forge world lifecycle bridge so client-only level lifecycle callbacks that do not have a backing `MinecraftServer` are ignored instead of being forwarded into Amber's server-context world events.

The release version is bumped across the full supported matrix to preserve Amber's parity policy. The lifecycle guard is applied to every Forge overlay, including legacy `WorldEvent` handlers and modern `LevelEvent` handlers.

Compatibility:
- No public API changes.
- Forge world load, unload, and save callbacks now require a non-null server before dispatching.

Fixes #21.

Checked:
- `./gradlew --no-daemon --configure-on-demand :forge:26.1.2:compileJava --console=plain`
- `./gradlew --no-daemon --configure-on-demand <all modified Forge compileJava tasks> --console=plain`
- Amber Conformance `26.1.2-forge` TeaKit runtime: `40 passed, 0 failed`
